### PR TITLE
Fixing recaptcha silenced system check key

### DIFF
--- a/settings_local.py
+++ b/settings_local.py
@@ -12,8 +12,11 @@ DATABASES = {
     }
 }
 
-SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error', 'models.E025',
-                          'fields.W903']
+SILENCED_SYSTEM_CHECKS = [
+    'django_recaptcha.recaptcha_test_key_error',
+    'models.E025',
+    'fields.W903'
+]
 
 ALLOWED_HOSTS = [
     'localhost',


### PR DESCRIPTION
Fixes an issue with the incorrect key used to silence local warnings of recaptcha keys not set.

https://github.com/django-recaptcha/django-recaptcha#local-development-and-functional-testing

```
ERRORS:
?: (django_recaptcha.recaptcha_test_key_error) RECAPTCHA_PRIVATE_KEY or RECAPTCHA_PUBLIC_KEY is making use of the Google test keys and will not behave as expected in a production environment
	HINT: Update settings.RECAPTCHA_PRIVATE_KEY and/or settings.RECAPTCHA_PUBLIC_KEY. Alternatively this check can be ignored by adding SILENCED_SYSTEM_CHECKS = ['django_recaptcha.recaptcha_test_key_error'] to your settings file.
ERROR: 1
```
